### PR TITLE
register with "contacts"

### DIFF
--- a/test/helper.js
+++ b/test/helper.js
@@ -171,6 +171,7 @@ module.exports = {
     const properties = Object.assign({
       client_name: Issuer.defaultHttpOptions.headers['User-Agent'],
       redirect_uris: [redirectUri],
+      contacts: ['dummy@dummy.org'],
       response_types: responseType ? [responseType.replace(/\+/g, ' ')] : ['code', 'id_token', 'code token', 'code id_token', 'id_token token', 'code id_token token', 'none'],
       grant_types: responseType && responseType.indexOf('token') === -1 ? ['authorization_code'] : ['implicit', 'authorization_code'],
     }, metadata);


### PR DESCRIPTION
the "contacts" claim will be required in the upcoming releases of the RP certification test suite and this would otherwise break the CI tests